### PR TITLE
UICAL-46 Modify build/publish workflow for Jenkins automation.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,5 @@ buildNPM {
   publishModDescriptor = 'no'
   runLint = 'yes'
   runTest = 'yes'
-}  
+  runScripts = ['npm build']
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,4 @@ buildNPM {
   publishModDescriptor = 'no'
   runLint = 'yes'
   runTest = 'yes'
-  runScripts = ['build']
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@ buildNPM {
   publishModDescriptor = 'no'
   runLint = 'yes'
   runTest = 'yes'
-  runScripts = ['npm build']
+  runScripts = ['build']
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/react-big-calendar",
-  "version": "1.0.2-pre.1",
+  "version": "1.0.2",
   "description": "Calendar! with events",
   "repository": "folio-org/react-big-calendar",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/react-big-calendar",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Calendar! with events",
   "repository": "folio-org/react-big-calendar",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/react-big-calendar",
-  "version": "1.0.2-alpha.1",
+  "version": "1.0.2-pre.1",
   "description": "Calendar! with events",
   "repository": "folio-org/react-big-calendar",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "tdd": "jest --watch",
     "release": "release",
     "prettier": "prettier '**/*js' !examples/bundle.js '!lib/**' --write ",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "postinstall": "yarn build"
   },
   "lint-staged": {
     "src/**/*.js": "eslint",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "release": "release",
     "prettier": "prettier '**/*js' !examples/bundle.js '!lib/**' --write ",
     "precommit": "lint-staged",
-    "postinstall": "yarn build"
+    "prepublish": "yarn build"
   },
   "lint-staged": {
     "src/**/*.js": "eslint",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,16 @@
 {
   "name": "@folio/react-big-calendar",
-  "version": "1.0.1",
+  "version": "1.0.2-alpha.1",
   "description": "Calendar! with events",
   "repository": "folio-org/react-big-calendar",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",
   "files": [
-    "src/",
-    "lib/css",
+    "lib/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"
@@ -65,6 +64,7 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.0",
     "@storybook/react": "^3.3.13",
+    "@folio/stripes-components": "^4.0.0",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
     "babel-eslint": "^8.0.0",
@@ -102,7 +102,6 @@
     "webpack-dev-server": "^2.9.5"
   },
   "dependencies": {
-    "@folio/stripes-components": "^4.0.0",
     "classnames": "^2.1.3",
     "date-arithmetic": "^3.0.0",
     "invariant": "^2.1.0",


### PR DESCRIPTION
# Purpose
The current setup publishes the /src directory which ended up causing build/transpile issues when included in platform-complete due to a conflict in babel dependencies.

## Approach
Set up the build/publish workflow so that this module solely controls its transpilation and performs it ahead of time, publishing the artifacts to npm-folio for usage. The stripes-components dependencies that do exist here are simply transpiled out to `require` statements, with the imported components being untouched since babel isn't explicitly told to transpile them.
Additionally, I've added a 'prepublish' key to `package.json` - this will execute a `build` command when a local `yarn install` is performed. This happens in dev setups as well as what Jenkins does before publishing. This allows for push-button publishing from Jenkins once a release/tag is generated.
`stripes-components` is now a `devDependency` since the only time it needs to be installed is when this component will be worked on - it's already present within a platform setup and in an isolated run of `ui-calendar`.

## Next steps
Set up a watch mechanism so that local changes can be built automatically for local dev environments... perhaps something using `npm-watch` or similar module - otherwise the 'build' command will need to be run to see updates within dependent projects. 